### PR TITLE
Adding check for writeability

### DIFF
--- a/terminalist.py
+++ b/terminalist.py
@@ -405,6 +405,11 @@ def manage(this_file: pathlib.Path):
             print(f"{new_interceptor} already exists! Not replacing.")
             return
 
+        if not os.access(new_interceptor.parent, os.W_OK):
+            print(f"{new_interceptor.parent} is not writable! This is a requirement. Exiting.")
+            sys.exit(1)
+            return
+
         new_interceptor.symlink_to(this_file)
         print(f"Added interception for {args.install}; try running `{args.install}` now.")
     elif args.self_update:

--- a/terminalist_test.py
+++ b/terminalist_test.py
@@ -97,6 +97,28 @@ class TestRunning(unittest.TestCase):
             self.assertIn("<name>", find_run.stdout)
             self.assertIn("The name argument does not have a flag", find_run.stdout)
 
+    def test_install_not_writable(self):
+        with tempfile.TemporaryDirectory() as t:
+            d = pathlib.Path(t)
+            shutil.copy(terminalist.__file__, d)
+
+            terminalist_script = d / "terminalist.py"
+            find = d / "find"
+
+            # Remove write bits.
+            try:
+                d.chmod(0o555)
+                install_run = subprocess.run(
+                    [str(terminalist_script), "--install", "find"],
+                    stdout=subprocess.PIPE,
+                    encoding="utf-8",
+                )
+                self.assertEqual(1, install_run.returncode)
+                self.assertIn("not writable", install_run.stdout)
+            finally:
+                # Restore settings, so that test clean up can happen.
+                d.chmod(0o777)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The directory in which terminalist is installed must be writable in
order for terminalist to manage the symlinks there. This was assumed to
be true; this PR adds an explicit check for it during install
(--install) time.